### PR TITLE
Added configuration options to Jobs Grid with icons dashboard portlet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /work/
 .idea
 *.iml
+.classpath
+.project
+.settings/

--- a/src/main/java/jenkins/plugins/jobicon/CustomIconJobsPortlet.java
+++ b/src/main/java/jenkins/plugins/jobicon/CustomIconJobsPortlet.java
@@ -15,32 +15,92 @@
  */
 package jenkins.plugins.jobicon;
 
+import java.util.List;
+
 import hudson.Extension;
 import hudson.model.Descriptor;
+import hudson.model.Job;
 import hudson.plugins.view.dashboard.DashboardPortlet;
+import hudson.util.ListBoxModel;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * A Dashboard portlet which is similar to the standard dashboard plugin 
- * Jobs Grid but includes the custom icon when configured.
+ * A Dashboard portlet which is similar to the standard dashboard plugin Jobs
+ * Grid but includes the custom icon when configured.
  * 
  * @author Jean-Christophe Sirot
  */
-public class CustomIconJobsPortlet extends DashboardPortlet
-{
+public class CustomIconJobsPortlet extends DashboardPortlet {
+
+	private int columnCount = 3;
+	private String iconSize = "24x24";
+	private boolean fillColumnFirst = false;
+
 	@DataBoundConstructor
-	public CustomIconJobsPortlet(String name)
-	{
+	public CustomIconJobsPortlet(
+	        String name,
+	        String iconSize,
+	        int columnCount,
+	        boolean fillColumnFirst) {
 		super(name);
+		this.iconSize = iconSize;
+		this.columnCount = columnCount;
+		this.fillColumnFirst = fillColumnFirst;
 	}
 
-	@Extension(optional=true)
-	public static class DescriptorImpl extends Descriptor<DashboardPortlet>
-	{
+	public int getColumnCount() {
+		return this.columnCount <= 0 ? 3 : this.columnCount;
+	}
+
+	public String getIconSize() {
+		return this.iconSize.isEmpty() ? "24x24" : this.iconSize;
+	}
+
+	public int getRowCount() {
+		int s = this.getDashboard().getJobs().size();
+		int rowCount = s / this.columnCount;
+		if (s % this.columnCount > 0) {
+			rowCount += 1;
+		}
+		return rowCount;
+	}
+
+	public boolean getFillColumnFirst() {
+		return this.fillColumnFirst;
+	}
+
+	public Job getJob(int curRow, int curColumun) {
+		List<Job> jobs = this.getDashboard().getJobs();
+		int idx = 0;
+		// get grid coordinates from given params
+		if (this.fillColumnFirst) {
+			idx = curRow + curColumun * this.getRowCount();
+			if (idx >= jobs.size()) {
+				return null;
+			}
+		} else {
+			idx = curColumun + curRow * this.columnCount;
+			if (idx >= jobs.size()) {
+				return null;
+			}
+		}
+		return jobs.get(idx);
+	}
+
+	@Extension(optional = true)
+	public static class DescriptorImpl extends Descriptor<DashboardPortlet> {
 		@Override
-		public String getDisplayName()
-		{
+		public String getDisplayName() {
 			return Messages.Dashboard_jobsGridWithIcons();
+		}
+
+		public ListBoxModel doFillIconSizeItems() {
+			ListBoxModel m = new ListBoxModel();
+			m.add("16x16","16x16");
+			m.add("24x24","24x24");
+			m.add("32x32","32x32");
+			return m;
 		}
 	}
 }

--- a/src/main/resources/jenkins/plugins/jobicon/CustomIconJobsPortlet/config.jelly
+++ b/src/main/resources/jenkins/plugins/jobicon/CustomIconJobsPortlet/config.jelly
@@ -1,0 +1,30 @@
+<!--
+      Contributed by syl20bnr, 2013
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ -->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Display name}">
+    <f:textbox name="portlet.name" field="name" default="${descriptor.getDisplayName()}" />
+  </f:entry>
+  <f:entry name="iconSize" title="Icon Size" field="iconSize">
+    <f:select />
+  </f:entry>
+  <f:entry title="${%Number of columns}">
+    <f:textbox name="columnCount" field="columnCount" />
+  </f:entry>
+  <f:block>
+    <f:checkbox name="fillColumnFirst" field="fillColumnFirst" />
+    ${%Fill column first}
+  </f:block>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/jobicon/CustomIconJobsPortlet/portlet.jelly
+++ b/src/main/resources/jenkins/plugins/jobicon/CustomIconJobsPortlet/portlet.jelly
@@ -15,33 +15,36 @@
  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:dp="/hudson/plugins/view/dashboard" xmlns:wi="/jenkins/plugins/jobicon" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <dp:decorate portlet="${it}" width="3">
+  <j:set var="h" value="${it.rowCount}"/>
+  <j:set var="w" value="${it.columnCount}"/>
+  <dp:decorate portlet="${it}" width="${w}">
     <j:set var="i" value="${1 - 1}"/>
-    <j:while test="${i &lt; jobs.size()}">
+    <j:while test="${i &lt; h}">
       <tr>
         <j:set var="j" value="${1 - 1}"/>
-        <j:while test="${i &lt; jobs.size() &amp;&amp; j &lt; 3}">
-          <j:set var="job" value="${jobs.get(i)}" />
-          <td style="border: 1px solid #bbb;">
-            <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
-              <a href="${job.shortUrl}build?delay=0sec">
-                <img src="${imagesURL}/16x16/clock.png"
-                     title="${%Schedule a build}" alt="${%Schedule a build}"
-                     border="0"
-                     align="middle"
-                     style="float: right; clear: none;" class="icon16x16"/>
-              </a>
-            </j:if>
-            <wi:jobLinkWithIcon job="${job}" iconSize="16x16"/>
-          </td>
-          <j:set var="i" value="${i + 1}"/>
-          <j:set var="j" value="${j + 1}"/>
-        </j:while>
-        <j:while test="${j &lt; 3}">
-          <td style="border: 1px solid #bbb;"></td>
+        <j:while test="${j &lt; w}">
+          <j:set var="job" value="${it.getJob(i, j)}" />
+          <j:if test="${!empty(job)}">
+            <td style="border: 1px solid #bbb;">
+              <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
+                <a href="${job.shortUrl}build?delay=0sec">
+                  <img src="${imagesURL}/16x16/clock.png"
+                       title="${%Schedule a build}" alt="${%Schedule a build}"
+                       border="0"
+                       align="middle"
+                       style="float: right; clear: none;"/>
+                </a>
+              </j:if>
+              <wi:jobLinkWithIcon job="${job}" iconSize="${it.iconSize}"/>
+            </td>
+          </j:if>
+          <j:if test="${empty(job)}">
+            <td style="border: 1px solid #bbb;"></td>
+          </j:if>
           <j:set var="j" value="${j + 1}"/>
         </j:while>
       </tr>
+      <j:set var="i" value="${i + 1}"/>
     </j:while>
   </dp:decorate>
 </j:jelly>


### PR DESCRIPTION
Hi,

Those modifications are based on a pull request I made for the legacy Jobs Grid portlet. They add:
- An option to configure the number of columns
- An option to fill columns first
- An option to choose the icon size.

![customiconconfig01](https://f.cloud.github.com/assets/1243537/79987/ff5471de-61e3-11e2-810b-2df235433d2f.png)

![customiconconfig02](https://f.cloud.github.com/assets/1243537/79988/0353b2b8-61e4-11e2-991e-093a89450afa.png)

Note: when updating the plug-in, the portlet is empty. The user have to edit the view and save it to bring back the grid.

Cheers,
syl20bnr
