### PR TITLE
Add hints to Graphics2D so that image resizing is smooth

### DIFF
--- a/src/main/java/jenkins/plugins/jobicon/CustomIconAction.java
+++ b/src/main/java/jenkins/plugins/jobicon/CustomIconAction.java
@@ -18,6 +18,11 @@ package jenkins.plugins.jobicon;
 import hudson.FilePath;
 import hudson.model.Action;
 import hudson.model.Job;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.servlet.ServletException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -25,19 +30,15 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import javax.servlet.ServletException;
-import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * This action add {@code /customIcon/} to the job URL space and serve the
  * icon image.
- * 
+ *
  * This action accepts the query parameter {@code size} with these
  * acceptable values {@code 16x16}, {@code 24x24} and {@code 32x32}. If this
  * query parameter is present the icon image is resized before being served.
- * 
+ *
  * @author Jean-Christophe Sirot
  */
 public class CustomIconAction implements Action
@@ -47,7 +48,7 @@ public class CustomIconAction implements Action
 
 	/**
 	 * Creates a new {@code CustomIconAction}.
-	 * 
+	 *
 	 * @param job the owner job
 	 */
 	public CustomIconAction(Job job)
@@ -56,19 +57,16 @@ public class CustomIconAction implements Action
 		this.cache = new HashMap<Integer, byte[]>();
 	}
 
-	@Override
 	public String getIconFileName()
 	{
 		return null;
 	}
 
-	@Override
 	public String getDisplayName()
 	{
 		return "Custom Icon";
 	}
 
-	@Override
 	public String getUrlName()
 	{
 		return "customIcon";
@@ -76,7 +74,7 @@ public class CustomIconAction implements Action
 
 	/**
 	 * Handles the action call.
-	 * 
+	 *
 	 * @param req  the stapler request
 	 * @param rsp  the stapler response
 	 */
@@ -104,7 +102,7 @@ public class CustomIconAction implements Action
 
 	/**
 	 * Resizes the icon image or gets it from cache.
-	 * 
+	 *
 	 * @param url  the original image URL
 	 * @param size  the requested size
 	 * @return  the resized image data
@@ -113,7 +111,7 @@ public class CustomIconAction implements Action
 	{
 		if (cache.get(size) != null) {
 			return cache.get(size);
-		} 
+		}
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		ImageUtils.resize(url.openStream(), out, size);
 		cache.put(size, out.toByteArray());

--- a/src/main/java/jenkins/plugins/jobicon/ImageUtils.java
+++ b/src/main/java/jenkins/plugins/jobicon/ImageUtils.java
@@ -15,38 +15,49 @@
  */
 package jenkins.plugins.jobicon;
 
-import java.awt.Graphics2D;
+import javax.imageio.ImageIO;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import javax.imageio.ImageIO;
 
 /**
  * Utility functions for images.
- * 
- * @author Jean-Christophe Sirot
+ *
+ * @author Jean-Christophe Sirot, Nick Palmer
  */
 class ImageUtils
 {
 	private ImageUtils()
 	{
 	}
-	
+
 	/**
-	 * Resizes the image to 64x64 pixels and convert to PNG.
-	 * @param in the original image
-	 * @param out the converted image
-	 * @param size the image size
-	 * @throws IOException on I/O error
+	 * Resize the image from an InputStream to a specific height/width size
+	 *
+	 * @param in Image InputStream
+	 * @param out OutputStream to write the resized image to
+	 * @param size size of the output image height/width in pixels
+	 * @throws IOException Thrown in the image cannot be read/written to the in/out streams
 	 */
-	static void resize(InputStream in, OutputStream out, int size) throws IOException
-	{
+	static void resize(InputStream in, OutputStream out, int size)
+		throws IOException {
 		BufferedImage originalImage = ImageIO.read(in);
 		BufferedImage resizedImage = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+
 		Graphics2D g = resizedImage.createGraphics();
+
+		g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setComposite(AlphaComposite.Src);
+
 		g.drawImage(originalImage, 0, 0, size, size, null);
+
 		g.dispose();
+
+
 		ImageIO.write(resizedImage, "png", out);
 	}
 }

--- a/src/main/resources/jenkins/plugins/jobicon/CustomIconColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/jobicon/CustomIconColumn/column.jelly
@@ -18,7 +18,7 @@
   <td>
     <j:if test="${job.getProperty('jenkins.plugins.jobicon.CustomIconProperty')!=null}">
       <a href="${job.shortUrl}" title="${job.name}">
-        <img src="${job.shortUrl}customIcon/?size=${subIconSize}" class="icon${iconSize}" />
+        <img src="${job.shortUrl}customIcon/?size=${iconSize}" class="icon${iconSize}" />
       </a>
     </j:if>
   </td>


### PR DESCRIPTION
I modified the resize image method to use bilinear interpolation when resizing the images, leading to smoother looking images at smaller sizes.
I also updated the column image tag to have a url with the same image size as the class that will be used. Before when Jenkins was set to show Large icons the class was icon32x32 but the URL was for size=24x24 leading to a stretched image.

People with existing icons will have to re-upload them if they were not 64x64 as the old resize method would have been used when the images got stored originally.
