### PR TITLE
JENKINS-28248: Changed URL in column to fix broken link on node-page …

### DIFF
--- a/src/main/resources/jenkins/plugins/jobicon/CustomIconColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/jobicon/CustomIconColumn/column.jelly
@@ -17,8 +17,8 @@
 <j:jelly xmlns:j="jelly:core">
   <td>
     <j:if test="${job.getProperty('jenkins.plugins.jobicon.CustomIconProperty')!=null}">
-      <a href="${job.shortUrl}" title="${job.name}">
-        <img src="${job.shortUrl}customIcon/?size=${subIconSize}" class="icon${iconSize}" />
+      <a href="${jobBaseUrl}${job.shortUrl}" title="${job.name}">
+        <img src="${jobBaseUrl}${job.shortUrl}customIcon/?size=${subIconSize}" class="icon${iconSize}" />
       </a>
     </j:if>
   </td>


### PR DESCRIPTION
This is a fix to JENKINS-28248:
I've updated the URL to the job page and to the icon image to match the pattern used by JobColumn and others. The replaced implementation caused broken image and invalid link when listed on a build-node page. See JENKINS-28248 (https://issues.jenkins-ci.org/browse/JENKINS-28248).
